### PR TITLE
fix: mypage 마진 등 디테일 수정

### DIFF
--- a/lib/core/theme/app_text_styles.dart
+++ b/lib/core/theme/app_text_styles.dart
@@ -142,6 +142,12 @@ class AppTypography {
     fontWeight: FontWeight.w500, // Medium
     fontFamily: 'Pretendard-Medium',
   );
+  static const TextStyle link12 = TextStyle(
+    fontSize: 12,
+    height: 16 / 12,
+    fontWeight: FontWeight.w600, // Medium
+    fontFamily: 'Pretendard-SemiBold',
+  );
 }
 
 // 사용 예제

--- a/lib/presentation/pages/mypage/guest_my_page_screen.dart
+++ b/lib/presentation/pages/mypage/guest_my_page_screen.dart
@@ -7,6 +7,7 @@ import 'package:personalized_travel_recommendations/presentation/widgets/reusabl
 import 'package:personalized_travel_recommendations/presentation/pages/mypage/logged_in_my_page_screen.dart';
 import 'package:personalized_travel_recommendations/presentation/pages/mypage/my_page_notice_screen.dart';
 
+
 class GuestMyPageScreen extends StatelessWidget {
   const GuestMyPageScreen({super.key});
 
@@ -19,7 +20,7 @@ class GuestMyPageScreen extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             const MyPageHeader(),
-            const SizedBox(height: 8),
+            const SizedBox(height: 20), // 로그인 카드 위 여백
 
             // 🔹 로그인 유도 카드
             ReusablePromptCard(
@@ -36,12 +37,12 @@ class GuestMyPageScreen extends StatelessWidget {
               },
             ),
 
-            const SizedBox(height: 24),
+            const SizedBox(height: 0), // 로그인 ↔ 공지사항
 
             // 🔹 설정 항목
             SettingsListItem(
               leadingIcon: Image.asset(
-                'assets/icons/Solid/png/clipboard-check.png',
+                'assets/icons/Outline/png/clipboard-check.png',
                 width: 24,
                 height: 24,
                 color: AppColors.neutral60,
@@ -66,7 +67,7 @@ class GuestMyPageScreen extends StatelessWidget {
                 height: 24,
                 color: AppColors.neutral60,
               ),
-              label: '고객센터',
+              label: '고객 센터',
               onTap: () => Navigator.pushNamed(context, '/support'),
             ),
             const CustomDivider(),

--- a/lib/presentation/pages/mypage/logged_in_my_page_screen.dart
+++ b/lib/presentation/pages/mypage/logged_in_my_page_screen.dart
@@ -5,9 +5,9 @@ import 'package:personalized_travel_recommendations/presentation/widgets/profile
 import 'package:personalized_travel_recommendations/presentation/widgets/feature_icon_button.dart';
 import 'package:personalized_travel_recommendations/presentation/widgets/settings_list_item.dart';
 import 'package:personalized_travel_recommendations/presentation/widgets/custom_divider.dart';
-import 'package:personalized_travel_recommendations/presentation/pages/mypage/my_page_wishlist_screen.dart';
 import 'package:personalized_travel_recommendations/presentation/pages/mypage/guest_my_page_screen.dart';
 import 'package:personalized_travel_recommendations/presentation/pages/mypage/my_page_notice_screen.dart';
+import 'package:personalized_travel_recommendations/presentation/pages/mypage/my_page_wishlist_modal_wrapper.dart';
 
 class LoggedInMyPageScreen extends StatelessWidget {
   const LoggedInMyPageScreen({super.key});
@@ -25,7 +25,7 @@ class LoggedInMyPageScreen extends StatelessWidget {
 
             // 🔹 사용자 프로필 카드
             const Padding(
-              padding: EdgeInsets.symmetric(horizontal: 16),
+              padding: EdgeInsets.symmetric(horizontal: 20),
               child: ProfileHeader(
                 nickname: '재성구리',
                 daysTogether: 125,
@@ -38,7 +38,7 @@ class LoggedInMyPageScreen extends StatelessWidget {
 
             // 🔹 기능 아이콘 4개
             Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
+              padding: const EdgeInsets.symmetric(horizontal: 20),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
@@ -63,11 +63,11 @@ class LoggedInMyPageScreen extends StatelessWidget {
                     label: '찜한 목록',
                     count: 4,
                     onTap: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) => const WishlistScreen(),
-                        ),
+                      showModalBottomSheet(
+                        context: context,
+                        isScrollControlled: true,
+                        backgroundColor: Colors.transparent,
+                        builder: (context) => const WishlistModalWrapper(),
                       );
                     },
                     backgroundColor: AppColors.indigo60,
@@ -115,7 +115,7 @@ class LoggedInMyPageScreen extends StatelessWidget {
 
             SettingsListItem(
               leadingIcon: Image.asset(
-                'assets/icons/Solid/png/shopping-bag.png',
+                'assets/icons/Outline/png/shopping-bag.png',
                 width: 24,
                 height: 24,
                 color: AppColors.neutral60,
@@ -127,7 +127,7 @@ class LoggedInMyPageScreen extends StatelessWidget {
 
             SettingsListItem(
               leadingIcon: Image.asset(
-                'assets/icons/Solid/png/clipboard-check.png',
+                'assets/icons/Outline/png/clipboard-check.png',
                 width: 24,
                 height: 24,
                 color: AppColors.neutral60,
@@ -178,13 +178,13 @@ class LoggedInMyPageScreen extends StatelessWidget {
                 );
               },
             ),
-            const Padding(
-              padding: EdgeInsets.only(left: 72),
-              child: Text(
-                'Log out the account',
-                style: TextStyle(
-                  fontSize: 12,
-                  color: AppColors.neutral40,
+            Transform.translate( //
+              offset: const Offset(0, -8), // 위로 8px 당겨 붙이기
+              child: const Padding(
+                padding: EdgeInsets.only(left: 52),
+                child: Text(
+                  'Log out the account',
+                  style: TextStyle(fontSize: 12, color: AppColors.neutral40),
                 ),
               ),
             ),

--- a/lib/presentation/pages/mypage/my_page_support_center_screen.dart
+++ b/lib/presentation/pages/mypage/my_page_support_center_screen.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:personalized_travel_recommendations/core/theme/app_colors.dart';
+import 'package:personalized_travel_recommendations/core/theme/app_text_styles.dart';
+
+class SupportCenterScreen extends StatelessWidget {
+  const SupportCenterScreen({super.key});
+
+  final List<Map<String, dynamic>> items = const [
+    {'label': '여행 일정 변경/취소 규정이 궁금해요.', 'icon': Icons.info_outline},
+    {'label': '여행 일정을 변경하고 싶어요.', 'icon': Icons.calendar_today_outlined},
+    {'label': '예약을 취소하고 싶어요.', 'icon': Icons.cancel_outlined},
+    {'label': '취소 신청이 잘 되었는지 궁금해요.', 'icon': Icons.hourglass_empty},
+    {'label': '탑승 정보(항공/기차 등)를 수정하고 싶어요.', 'icon': Icons.airplane_ticket_outlined},
+    {'label': '패키지/티켓을 취소하고 싶어요.', 'icon': Icons.receipt_long},
+    {'label': '픽업/샌딩 관련 문의가 있어요.', 'icon': Icons.directions_car},
+    {'label': '숙소에 요청할 것이 있어요.', 'icon': Icons.hotel},
+    {'label': '채팅 상담', 'icon': Icons.chat},
+    {'label': '전화 상담 요청', 'icon': Icons.call},
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.white,
+      appBar: AppBar(
+        backgroundColor: AppColors.white,
+        elevation: 0,
+        centerTitle: true,
+        leading: IconButton(
+          icon: Image.asset(
+            'assets/icons/Solid/png/cheveron-left.png',
+            width: 24,
+            height: 24,
+            color: AppColors.neutral60,
+          ),
+          onPressed: () => Navigator.pop(context),
+        ),
+        title: const Text('고객센터', style: AppTypography.subtitle20Bold),
+      ),
+      body: ListView.separated(
+        padding: const EdgeInsets.symmetric(vertical: 12),
+        itemCount: items.length,
+        separatorBuilder: (_, __) => const Divider(height: 1),
+        itemBuilder: (context, index) {
+          return ListTile(
+            leading: Icon(items[index]['icon'], color: AppColors.neutral60),
+            title: Text(
+              items[index]['label'],
+              style: AppTypography.body16Regular.copyWith(color: AppColors.neutral90),
+            ),
+            trailing: const Icon(Icons.chevron_right, color: AppColors.neutral40),
+            onTap: () {
+              // 각 항목 클릭 시 처리
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/mypage/my_page_wishlist_modal_wrapper.dart
+++ b/lib/presentation/pages/mypage/my_page_wishlist_modal_wrapper.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:personalized_travel_recommendations/core/theme/app_colors.dart';
+import 'package:personalized_travel_recommendations/presentation/pages/mypage/my_page_wishlist_screen.dart';
+
+class WishlistModalWrapper extends StatelessWidget {
+  const WishlistModalWrapper({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return DraggableScrollableSheet(
+      expand: false,
+      initialChildSize: 0.95,
+      maxChildSize: 0.95,
+      minChildSize: 0.7,
+      builder: (context, scrollController) {
+        return Container(
+          decoration: const BoxDecoration(
+            color: AppColors.white,
+            borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+          ),
+          child: WishlistScreen(scrollController: scrollController),
+        );
+      },
+    );
+  }
+}

--- a/lib/presentation/pages/mypage/my_page_wishlist_screen.dart
+++ b/lib/presentation/pages/mypage/my_page_wishlist_screen.dart
@@ -4,8 +4,11 @@ import 'package:personalized_travel_recommendations/core/theme/app_text_styles.d
 import 'package:personalized_travel_recommendations/presentation/widgets/favorite_card.dart';
 import 'package:personalized_travel_recommendations/presentation/widgets/tab_bar_selector.dart';
 
+
 class WishlistScreen extends StatefulWidget {
-  const WishlistScreen({super.key});
+  final ScrollController? scrollController;
+
+  const WishlistScreen({super.key, this.scrollController});
 
   @override
   State<WishlistScreen> createState() => _WishlistScreenState();
@@ -31,45 +34,56 @@ class _WishlistScreenState extends State<WishlistScreen>
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: AppColors.white,
-      appBar: AppBar(
-        backgroundColor: AppColors.white,
-        elevation: 0,
-        centerTitle: true,
-        automaticallyImplyLeading: false, // ← 자동 아이콘 제거
-        leading: IconButton(
-          icon: Image.asset(
-            'assets/icons/Solid/png/cheveron-left.png',
-            width: 24,
-            height: 24,
-            color: AppColors.neutral60, // 원하는 색상 지정
-          ),
-          onPressed: () {
-            Navigator.pop(context); // 또는 다른 기능 원하시면 수정 가능
-          },
-        ),
-        title: const Text('찜한 목록', style: AppTypography.subtitle20Bold),
-        bottom: PreferredSize(
-          preferredSize: const Size.fromHeight(48),
-          child: TabBarSelector(
-            tabs: _tabs,
-            selectedIndex: _tabController.index,
-            onTap: (index) {
-              setState(() {
-                _tabController.index = index;
-              });
-            },
-          ),
-        ),
-      ),
-
-      body: TabBarView(
-        controller: _tabController,
+    return SafeArea(
+      child: Column(
         children: [
-          _buildListView('여행지'),
-          _buildListView('패키지'),
-          _buildListView('컨텐츠'),
+          const SizedBox(height: 8),
+          // 🔹 드래그 인디케이터
+          Container(
+            width: 40,
+            height: 4,
+            decoration: BoxDecoration(
+              color: AppColors.neutral40,
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+          const SizedBox(height: 16),
+
+          // 🔹 제목
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 20),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text('찜한 목록', style: AppTypography.title24Bold),
+            ),
+          ),
+
+
+          // 🔹 탭바
+          Padding(
+            padding: const EdgeInsets.only(top: 12),
+            child: TabBarSelector(
+              tabs: _tabs,
+              selectedIndex: _tabController.index,
+              onTap: (index) {
+                setState(() {
+                  _tabController.index = index;
+                });
+              },
+            ),
+          ),
+
+          // 🔹 콘텐츠
+          Expanded(
+            child: TabBarView(
+              controller: _tabController,
+              children: [
+                _buildListView('여행지'),
+                _buildListView('패키지'),
+                _buildListView('컨텐츠'),
+              ],
+            ),
+          ),
         ],
       ),
     );
@@ -115,14 +129,14 @@ class _WishlistScreenState extends State<WishlistScreen>
     } else {
       items = [
         {
-          'imageUrl': 'assets/images/contents.png',
+          'imageUrl': 'assets/images/SagradaFamilia.png',
           'title': '도시 및 국가별 여행 가이드',
           'subtitle': '여행 정보',
           'rating': 0.0,
           'tags': <String>[],
         },
         {
-          'imageUrl': 'assets/images/contents.png',
+          'imageUrl': 'assets/images/SagradaFamilia.png',
           'title': '도시 및 국가별 여행 가이드',
           'subtitle': '여행 정보',
           'rating': 0.0,
@@ -132,6 +146,7 @@ class _WishlistScreenState extends State<WishlistScreen>
     }
 
     return ListView.separated(
+      controller: widget.scrollController,
       padding: const EdgeInsets.all(16),
       itemCount: items.length,
       separatorBuilder: (_, __) => const SizedBox(height: 12),

--- a/lib/presentation/widgets/favorite_card.dart
+++ b/lib/presentation/widgets/favorite_card.dart
@@ -38,8 +38,9 @@ class FavoriteCard extends StatelessWidget {
           borderRadius: BorderRadius.circular(12),
           boxShadow: [
             BoxShadow(
-              color: AppColors.neutral20.withAlpha((0.4 * 255).toInt()),
-              blurRadius: 4,
+              color: AppColors.neutral40.withAlpha((0.4*255).toInt()),
+              blurRadius: 8,
+              offset: const Offset(0, 4),
             ),
           ],
         ),
@@ -94,11 +95,16 @@ class FavoriteCard extends StatelessWidget {
                                   ),
                                 ),
                               ),
-                              Image.asset(
-                                'assets/icons/Solid/png/heart.png',
-                                width: 20,
-                                height: 20,
-                                color: AppColors.error60,
+
+                              Padding(
+                                padding: const EdgeInsets.only(right: 15), // ← 왼쪽으로 이동
+                                child: Image.asset(
+                                  'assets/icons/Solid/png/heart.png',
+                                  width: 26,
+                                  height: 26,
+                                  fit: BoxFit.cover,
+                                  color: AppColors.error60,
+                                ),
                               ),
                             ],
                           ),
@@ -142,13 +148,14 @@ class FavoriteCard extends StatelessWidget {
     if (isContent) {
       return Container(
         margin: const EdgeInsets.only(bottom: 16),
+        width: double.infinity,
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(16),
           boxShadow: [
             BoxShadow(
-              color: AppColors.neutral20.withAlpha((0.3 * 255).toInt()),
-              blurRadius: 6,
-              offset: const Offset(0, 2),
+              color: AppColors.neutral100.withAlpha((0.1*255).toInt()),
+              blurRadius: 10,
+              offset: const Offset(0, 4),
             ),
           ],
         ),
@@ -156,84 +163,77 @@ class FavoriteCard extends StatelessWidget {
           borderRadius: BorderRadius.circular(16),
           child: Stack(
             children: [
-              /// ✅ 배경 이미지
+              // ✅ 배경 이미지
               SizedBox(
                 width: double.infinity,
-                height: 160,
+                height: 125,
                 child: isAssetImage
-                    ? Image.asset(
-                  imageUrl,
-                  fit: BoxFit.cover,
-                )
-                    : Image.network(
-                  imageUrl,
-                  fit: BoxFit.cover,
-                ),
+                    ? Image.asset(imageUrl, fit: BoxFit.cover)
+                    : Image.network(imageUrl, fit: BoxFit.cover),
               ),
 
-              /// ✅ 상단 하트
+              // ✅ 상단 하트 아이콘
               Positioned(
                 top: 8,
                 right: 12,
                 child: Image.asset(
                   'assets/icons/Solid/png/heart.png',
-                  width: 20,
-                  height: 20,
+                  width: 26,
+                  height: 26,
+                  fit: BoxFit.cover,
                   color: AppColors.error60,
                 ),
               ),
 
-              /// ✅ 텍스트 & ➤ 같은 줄
+              // ✅ 텍스트 및 > 아이콘
               Positioned.fill(
-                child: Align(
-                  alignment: Alignment.centerLeft,
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 16),
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        const Text(
-                          '여행 정보',
-                          style: TextStyle(
-                            color: Colors.white,
-                            fontSize: 12,
-                            fontWeight: FontWeight.w500,
-                          ),
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(28, 31, 28, 28),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text(
+                        '여행 정보',
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 14,
+                          fontWeight: FontWeight.w500,
                         ),
-                        const SizedBox(height: 4),
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            const Expanded(
-                              child: Text(
-                                '도시 및 국가별 여행 가이드',
-                                style: TextStyle(
-                                  color: Colors.white,
-                                  fontSize: 16,
-                                  fontWeight: FontWeight.bold,
-                                  overflow: TextOverflow.ellipsis,
-                                  shadows: [
-                                    Shadow(
-                                      blurRadius: 4,
-                                      color: Colors.black54,
-                                      offset: Offset(1, 1),
-                                    ),
-                                  ],
-                                ),
+                      ),
+                      const SizedBox(height: 4),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          const Expanded(
+                            child: Text(
+                              '도시 및 국가별 여행 가이드',
+                              style: TextStyle(
+                                color: Colors.white,
+                                fontSize: 22,
+                                fontWeight: FontWeight.bold,
+                                overflow: TextOverflow.ellipsis,
+                                shadows: [
+                                  Shadow(
+                                    blurRadius: 4,
+                                    color: Colors.black54,
+                                    offset: Offset(1, 1),
+                                  ),
+                                ],
                               ),
                             ),
-                            const SizedBox(width: 8),
-                            Image.asset(
-                              'assets/icons/Outline/png/cheveron-right.png',
-                              width: 18,
-                              height: 18,
-                              color: Colors.white,
-                            ),
-                          ],
-                        ),
-                      ],
-                    ),
+                          ),
+                          const SizedBox(width: 8),
+                          Image.asset(
+                            'assets/icons/Outline/png/cheveron-right.png',
+                            width: 24,
+                            height: 24,
+                            fit: BoxFit.cover,
+                            color: Colors.white,
+                          ),
+                        ],
+                      ),
+                    ],
                   ),
                 ),
               ),
@@ -253,9 +253,9 @@ class FavoriteCard extends StatelessWidget {
         color: AppColors.white,
         boxShadow: [
           BoxShadow(
-            color: AppColors.neutral20.withAlpha((0.4 * 255).toInt()),
-            blurRadius: 6,
-            offset: const Offset(0, 2),
+            color: AppColors.neutral40.withAlpha((0.4*255).toInt()),
+            blurRadius: 8,
+            offset: const Offset(0, 4),
           ),
         ],
       ),
@@ -275,8 +275,9 @@ class FavoriteCard extends StatelessWidget {
                 right: 8,
                 child: Image.asset(
                   'assets/icons/Solid/png/heart.png',
-                  width: 22,
-                  height: 22,
+                  width: 26,
+                  height: 26,
+                  fit: BoxFit.cover,
                   color: AppColors.error60,
                 ),
               ),
@@ -314,8 +315,9 @@ class FavoriteCard extends StatelessWidget {
                   children: [
                     Image.asset(
                       'assets/icons/Solid/png/star.png',
-                      width: 20,
-                      height: 20,
+                      width: 26,
+                      height: 26,
+                      fit: BoxFit.cover,
                       color: AppColors.warning40,
                     ),
                     const SizedBox(width: 4),
@@ -333,7 +335,7 @@ class FavoriteCard extends StatelessWidget {
             ),
           ),
         ],
-      ),
+      )
     );
   }
 }

--- a/lib/presentation/widgets/feature_icon_button.dart
+++ b/lib/presentation/widgets/feature_icon_button.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:personalized_travel_recommendations/core/theme/app_colors.dart';
+import 'package:personalized_travel_recommendations/core/theme/app_text_styles.dart';
 
 class FeatureIconButton extends StatelessWidget {
-  final Widget icon; // IconData → Widget 변경
+  final Widget icon;
   final String label;
   final int count;
   final VoidCallback? onTap;
@@ -24,7 +25,7 @@ class FeatureIconButton extends StatelessWidget {
     return GestureDetector(
       onTap: onTap,
       child: Container(
-        width: 80,
+        width: 72,  //height 넣으니까 오류 나서 피그마 디자인과 다르게 진행
         padding: const EdgeInsets.symmetric(vertical: 12),
         decoration: BoxDecoration(
           color: backgroundColor,
@@ -33,22 +34,19 @@ class FeatureIconButton extends StatelessWidget {
         child: Column(
           children: [
             SizedBox(
-              height: 28,
-              width: 28,
+              height: 24,
+              width: 24,
               child: icon,
             ),
             const SizedBox(height: 4),
             Text(
               label,
-              style: TextStyle(
-                color: textColor,
-                fontSize: 14,
-              ),
+              style: AppTypography.caption12Medium.copyWith(color: textColor),
             ),
             const SizedBox(height: 4),
             Text(
               count.toString(),
-              style: TextStyle(
+              style: AppTypography.caption12Medium.copyWith(
                 color: textColor,
                 fontWeight: FontWeight.bold,
               ),

--- a/lib/presentation/widgets/mypage_header.dart
+++ b/lib/presentation/widgets/mypage_header.dart
@@ -15,19 +15,19 @@ class MyPageHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 24, 16, 8),
+      padding: const EdgeInsets.fromLTRB(25, 66, 16, 8),
       child: Row(
         children: [
           Text(
             title,
-            style: AppTypography.subtitle20Bold.copyWith(
+            style: AppTypography.title24Bold.copyWith(
               color: AppColors.neutral90,
             ),
           ),
           const SizedBox(width: 8),
           Text(
             '| $brandName',
-            style: AppTypography.subtitle18Regular.copyWith(
+            style: AppTypography.title24Bold.copyWith(
               color: AppColors.neutral40,
             ),
           ),

--- a/lib/presentation/widgets/profile_header.dart
+++ b/lib/presentation/widgets/profile_header.dart
@@ -40,15 +40,15 @@ class ProfileHeader extends StatelessWidget {
               children: [
                 Text(
                   nickname,
-                  style: AppTypography.subtitle18Bold.copyWith(
+                  style: AppTypography.subtitle16SemiBold.copyWith(
                     color: AppColors.white,
                   ),
                 ),
                 const SizedBox(height: 4),
                 Text(
                   '맛상추와 함께한지 $daysTogether일째\n그동안 총 $travelCount번의 여행을 떠났어요 :)',
-                  style: AppTypography.body14Regular.copyWith(
-                    color: AppColors.neutral50,
+                  style: AppTypography.caption12Regular.copyWith(
+                    color: AppColors.white,
                     height: 1.4,
                   ),
                 ),

--- a/lib/presentation/widgets/reusable_prompt_card.dart
+++ b/lib/presentation/widgets/reusable_prompt_card.dart
@@ -19,8 +19,8 @@ class ReusablePromptCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      margin: const EdgeInsets.symmetric(horizontal: 16),
-      padding: const EdgeInsets.all(16),
+      margin: const EdgeInsets.fromLTRB(20, 0, 20, 40),
+      padding: const EdgeInsets.all(20),
       decoration: BoxDecoration(
         color: AppColors.indigo100,
         borderRadius: BorderRadius.circular(16),
@@ -33,14 +33,14 @@ class ReusablePromptCard extends StatelessWidget {
               children: [
                 Text(
                   title,
-                  style: AppTypography.subtitle18Bold.copyWith(
+                  style: AppTypography.subtitle16SemiBold.copyWith(
                     color: AppColors.white,
                   ),
                 ),
                 const SizedBox(height: 4),
                 Text(
                   subtitle,
-                  style: AppTypography.body14Regular.copyWith(
+                  style: AppTypography.caption12Regular.copyWith(
                     color: AppColors.white,
                   ),
                 ),
@@ -51,12 +51,12 @@ class ReusablePromptCard extends StatelessWidget {
             onPressed: onTap,
             style: ElevatedButton.styleFrom(
               backgroundColor: AppColors.white,
-              foregroundColor: AppColors.purple80,
+              foregroundColor: AppColors.neutral90,
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(20),
               ),
               padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
-              textStyle: AppTypography.button14,
+              textStyle: AppTypography.link12,
             ),
             child: Text(buttonText),
           ),

--- a/lib/presentation/widgets/settings_list_item.dart
+++ b/lib/presentation/widgets/settings_list_item.dart
@@ -20,7 +20,7 @@ class SettingsListItem extends StatelessWidget {
       leading: leadingIcon,
       title: Text(
         label,
-        style: AppTypography.body16Regular.copyWith(
+        style: AppTypography.body14SemiBold.copyWith(
           color: AppColors.neutral80,
         ),
       ),

--- a/lib/presentation/widgets/tag_chip.dart
+++ b/lib/presentation/widgets/tag_chip.dart
@@ -13,13 +13,13 @@ class TagChip extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
       decoration: BoxDecoration(
         color: AppColors.indigo60, //태그 배경색
-        borderRadius: BorderRadius.circular(30),
+        borderRadius: BorderRadius.circular(8),
       ),
       child: Text(
         label,
         style: const TextStyle(
           color: AppColors.white, //태그 글자색
-          fontSize: 12,
+          fontSize: 14,
         ),
       ),
     );


### PR DESCRIPTION
1. 마이페이지 레이아웃 개선
: 마진, 패징, 텍스트 정렬 디테일 조절

2. 찜한 목록 (여행지, 패키지, 컨텐츠) 마드 스타일 통일
: 카드별 그림자 적용 및 적돈
: 컨텐츠 카드 이미지 사이즈 문제 해결을 위해  보여지는 이미지를 임시로 변경해둠.
추후 새로운 이미지 파일 업로드해서 수정 예정

3. 패키지 카드
: 해시캐드 모서리 radius 감소
: 하트 위치와 하트 등 아이콘 사이즈 조절

4. 찜한 목록에 모달 드래그 인디케이터? 추가