### PR TITLE
fix: 마이페이지-공지사항, 고객센터 ui 개선 및 내비 연결

### DIFF
--- a/lib/presentation/pages/mypage/guest_my_page_screen.dart
+++ b/lib/presentation/pages/mypage/guest_my_page_screen.dart
@@ -6,7 +6,7 @@ import 'package:personalized_travel_recommendations/presentation/widgets/custom_
 import 'package:personalized_travel_recommendations/presentation/widgets/reusable_prompt_card.dart';
 import 'package:personalized_travel_recommendations/presentation/pages/mypage/logged_in_my_page_screen.dart';
 import 'package:personalized_travel_recommendations/presentation/pages/mypage/my_page_notice_screen.dart';
-
+import 'package:personalized_travel_recommendations/presentation/pages/mypage/my_page_support_center_screen.dart';
 
 class GuestMyPageScreen extends StatelessWidget {
   const GuestMyPageScreen({super.key});
@@ -68,7 +68,14 @@ class GuestMyPageScreen extends StatelessWidget {
                 color: AppColors.neutral60,
               ),
               label: '고객 센터',
-              onTap: () => Navigator.pushNamed(context, '/support'),
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => const SupportCenterScreen(),
+                  ),
+                );
+              },
             ),
             const CustomDivider(),
           ],

--- a/lib/presentation/pages/mypage/logged_in_my_page_screen.dart
+++ b/lib/presentation/pages/mypage/logged_in_my_page_screen.dart
@@ -6,10 +6,11 @@ import 'package:personalized_travel_recommendations/presentation/widgets/feature
 import 'package:personalized_travel_recommendations/presentation/widgets/settings_list_item.dart';
 import 'package:personalized_travel_recommendations/presentation/widgets/custom_divider.dart';
 import 'package:personalized_travel_recommendations/presentation/widgets/custom_navbar.dart';
-import 'package:personalized_travel_recommendations/presentation/pages/main_screen.dart'; // 반드시 올바른 경로
+import 'package:personalized_travel_recommendations/presentation/pages/main_screen.dart';
 import 'package:personalized_travel_recommendations/presentation/pages/mypage/my_page_notice_screen.dart';
 import 'package:personalized_travel_recommendations/presentation/pages/mypage/my_page_wishlist_modal_wrapper.dart';
 import 'package:personalized_travel_recommendations/presentation/pages/mypage/guest_my_page_screen.dart';
+import 'package:personalized_travel_recommendations/presentation/pages/mypage/my_page_support_center_screen.dart';
 
 class LoggedInMyPageScreen extends StatelessWidget {
   const LoggedInMyPageScreen({super.key});
@@ -157,7 +158,14 @@ class LoggedInMyPageScreen extends StatelessWidget {
                 color: AppColors.neutral60,
               ),
               label: '고객센터',
-              onTap: () {},
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => const SupportCenterScreen(),
+                  ),
+                );
+              },
             ),
             const CustomDivider(),
 

--- a/lib/presentation/pages/mypage/my_page_notice_screen.dart
+++ b/lib/presentation/pages/mypage/my_page_notice_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:personalized_travel_recommendations/core/theme/app_colors.dart';
 import 'package:personalized_travel_recommendations/core/theme/app_text_styles.dart';
 import 'package:personalized_travel_recommendations/presentation/widgets/custom_navbar.dart';
-import 'package:personalized_travel_recommendations/presentation/pages/main_screen.dart'; // MainScreen 경로에 맞게 수정
+import 'package:personalized_travel_recommendations/presentation/pages/main_screen.dart';
 
 class MyPageNoticeScreen extends StatelessWidget {
   const MyPageNoticeScreen({super.key});
@@ -45,51 +45,78 @@ class MyPageNoticeScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: AppColors.white,
-      appBar: AppBar(
-        elevation: 0,
-        backgroundColor: AppColors.white,
-        centerTitle: true,
-        leading: IconButton(
-          icon: Image.asset(
-            'assets/icons/Solid/png/cheveron-left.png',
-            width: 24,
-            height: 24,
-            color: AppColors.neutral60,
+      body: Column(
+        children: [
+          // 🔹 상단 제목
+          Padding(
+            padding: const EdgeInsets.fromLTRB(25, 66, 16, 8),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                '공지사항',
+                style: AppTypography.title24Bold.copyWith(color: AppColors.neutral90),
+              ),
+            ),
           ),
-          onPressed: () => Navigator.pop(context),
-        ),
-        title: const Text(
-          '공지사항',
-          style: AppTypography.subtitle20Bold,
-        ),
+
+          // 🔹 상단 공지
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 25),
+            color: AppColors.neutral10,
+            child: Row(
+              children: [
+                Text(
+                  '공지 ',
+                  style: AppTypography.caption12SemiBold.copyWith(
+                    color: AppColors.indigo80,
+                  ),
+                ),
+                const SizedBox(width: 4),
+                Expanded(
+                  child: Text(
+                    '항공권 취소/변경 접수 시간 변경 안내',
+                    style: AppTypography.caption12Regular.copyWith(
+                      color: AppColors.neutral70,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+          // 🔹 공지사항 리스트
+          Expanded(
+            child: ListView.separated(
+              padding: const EdgeInsets.symmetric(horizontal: 25, vertical: 8),
+              itemCount: _notices.length,
+              separatorBuilder: (_, __) => const Divider(color: AppColors.neutral20),
+              itemBuilder: (context, index) {
+                final notice = _notices[index];
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      notice['title'] ?? '',
+                      style: AppTypography.body14Medium.copyWith(color: AppColors.neutral90),
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      notice['date'] ?? '',
+                      style: AppTypography.caption12Regular.copyWith(color: AppColors.neutral40),
+                    ),
+                  ],
+                );
+              },
+            ),
+          ),
+        ],
       ),
-      body: ListView.separated(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        itemCount: _notices.length,
-        separatorBuilder: (_, __) =>
-        const Divider(color: AppColors.neutral20),
-        itemBuilder: (context, index) {
-          final notice = _notices[index];
-          return Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                notice['title'] ?? '',
-                style: AppTypography.body16Regular
-                    .copyWith(color: AppColors.neutral90),
-              ),
-              const SizedBox(height: 6),
-              Text(
-                notice['date'] ?? '',
-                style: AppTypography.caption12Regular
-                    .copyWith(color: AppColors.neutral40),
-              ),
-            ],
-          );
-        },
-      ),
+
+      // 🔹 하단 내비게이션
       bottomNavigationBar: BottomNavBar(
-        selectedIndex: 2, // 디자인상 My Page가 강조됨
+        selectedIndex: 2,
         onTap: (index) => _onNavTap(context, index),
       ),
     );

--- a/lib/presentation/pages/mypage/my_page_support_center_screen.dart
+++ b/lib/presentation/pages/mypage/my_page_support_center_screen.dart
@@ -1,59 +1,156 @@
 import 'package:flutter/material.dart';
 import 'package:personalized_travel_recommendations/core/theme/app_colors.dart';
 import 'package:personalized_travel_recommendations/core/theme/app_text_styles.dart';
+import 'package:personalized_travel_recommendations/presentation/widgets/custom_navbar.dart';
+import 'package:personalized_travel_recommendations/presentation/widgets/settings_list_item.dart';
+import 'package:personalized_travel_recommendations/presentation/pages/main_screen.dart';
 
 class SupportCenterScreen extends StatelessWidget {
   const SupportCenterScreen({super.key});
 
-  final List<Map<String, dynamic>> items = const [
-    {'label': '여행 일정 변경/취소 규정이 궁금해요.', 'icon': Icons.info_outline},
-    {'label': '여행 일정을 변경하고 싶어요.', 'icon': Icons.calendar_today_outlined},
-    {'label': '예약을 취소하고 싶어요.', 'icon': Icons.cancel_outlined},
-    {'label': '취소 신청이 잘 되었는지 궁금해요.', 'icon': Icons.hourglass_empty},
-    {'label': '탑승 정보(항공/기차 등)를 수정하고 싶어요.', 'icon': Icons.airplane_ticket_outlined},
-    {'label': '패키지/티켓을 취소하고 싶어요.', 'icon': Icons.receipt_long},
-    {'label': '픽업/샌딩 관련 문의가 있어요.', 'icon': Icons.directions_car},
-    {'label': '숙소에 요청할 것이 있어요.', 'icon': Icons.hotel},
-    {'label': '채팅 상담', 'icon': Icons.chat},
-    {'label': '전화 상담 요청', 'icon': Icons.call},
+  final List<Map<String, String>> inquiryItems = const [
+    {'emoji': '💰', 'label': '항공권 변경/취소 수수료 규정이 궁금해요.'},
+    {'emoji': '✈️', 'label': '항공권 일정을 변경하고 싶어요.'},
+    {'emoji': '❌', 'label': '항공권을 취소하고 싶어요.'},
+    {'emoji': '⏳', 'label': '항공권 취소 신청이 잘 되었는지 궁금해요.'},
+    {'emoji': '📝', 'label': '항공권 탑승자 정보를 변경하고 싶어요.'},
+    {'emoji': '🎫', 'label': '투어/티켓을 취소하고 싶어요.'},
+    {'emoji': '🚗', 'label': '투어의 픽업/샌딩 관련 문의가 있어요.'},
+    {'emoji': '🏨', 'label': '예약한 숙소에 요청할 것이 있어요.'},
   ];
+
+  final List<Map<String, String>> supportOptions = const [
+    {
+      'iconPath': 'assets/icons/Solid/png/chat.png',
+      'label': '채팅 상담'
+    },
+    {
+      'iconPath': 'assets/icons/Solid/png/phone.png',
+      'label': '항공 전화 상담'
+    },
+    {
+      'iconPath': 'assets/icons/Solid/png/phone.png',
+      'label': '항공 외 전화 상담'
+    },
+  ];
+
+
+  void _onNavTap(BuildContext context, int index) {
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(builder: (_) => MainScreen(initialIndex: index)),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: AppColors.white,
-      appBar: AppBar(
-        backgroundColor: AppColors.white,
-        elevation: 0,
-        centerTitle: true,
-        leading: IconButton(
-          icon: Image.asset(
-            'assets/icons/Solid/png/cheveron-left.png',
-            width: 24,
-            height: 24,
-            color: AppColors.neutral60,
-          ),
-          onPressed: () => Navigator.pop(context),
-        ),
-        title: const Text('고객센터', style: AppTypography.subtitle20Bold),
-      ),
-      body: ListView.separated(
-        padding: const EdgeInsets.symmetric(vertical: 12),
-        itemCount: items.length,
-        separatorBuilder: (_, __) => const Divider(height: 1),
-        itemBuilder: (context, index) {
-          return ListTile(
-            leading: Icon(items[index]['icon'], color: AppColors.neutral60),
-            title: Text(
-              items[index]['label'],
-              style: AppTypography.body16Regular.copyWith(color: AppColors.neutral90),
+      body: Column(
+        children: [
+          // 🔹 상단 제목 (AppBar 대신)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(25, 66, 16, 8),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                '문의하기',
+                style: AppTypography.title24Bold.copyWith(color: AppColors.neutral90),
+              ),
             ),
-            trailing: const Icon(Icons.chevron_right, color: AppColors.neutral40),
-            onTap: () {
-              // 각 항목 클릭 시 처리
-            },
-          );
-        },
+          ),
+
+          // 🔹 상단 공지
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 25),
+            color: AppColors.neutral10,
+            child: Row(
+              children: [
+                Text(
+                  '공지 ',
+                  style: AppTypography.caption12SemiBold.copyWith(
+                    color: AppColors.indigo80,
+                  ),
+                ),
+                const SizedBox(width: 4),
+                Expanded(
+                  child: Text(
+                    '항공권 취소/변경 접수 시간 변경 안내',
+                    style: AppTypography.caption12Regular.copyWith(
+                      color: AppColors.neutral70,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+
+          // 🔹 전체 리스트
+          Expanded(
+            child: ListView(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
+                  child: Text(
+                    '무엇을 도와드릴까요?',
+                    style: AppTypography.subtitle18Bold.copyWith(color: AppColors.neutral90),
+                  ),
+                ),
+                ...inquiryItems.map((item) {
+                  return SettingsListItem(
+                    leadingIcon: Text(item['emoji']!, style: const TextStyle(fontSize: 20)),
+                    label: item['label']!,
+                    onTap: () {},
+                  );
+                }),
+
+                const SizedBox(height: 16),
+
+                ...supportOptions.map((option) {
+                  return SettingsListItem(
+                    leadingIcon: Image.asset(
+                      option['iconPath']!,
+                      width: 20,
+                      height: 20,
+                      color: AppColors.neutral60, // 아이콘 색상 적용 (optional)
+                    ),
+                    label: option['label']!,
+                    onTap: () {},
+                  );
+                }),
+
+
+                const SizedBox(height: 24),
+
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('고객지원실 운영안내',
+                          style: AppTypography.body14SemiBold.copyWith(color: AppColors.neutral60)),
+                      const SizedBox(height: 6),
+                      Text(
+                        '채팅상담 연중무휴 24시간\n유선상담 연중무휴 09:00~18:00\n대표번호 1670-8208',
+                        style: AppTypography.caption12Regular.copyWith(color: AppColors.neutral40),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 36),
+              ],
+            ),
+          ),
+        ],
+      ),
+
+      // 🔹 하단 내비게이션 바
+      bottomNavigationBar: BottomNavBar(
+        selectedIndex: 2,
+        onTap: (index) => _onNavTap(context, index),
       ),
     );
   }

--- a/lib/presentation/widgets/profile_header.dart
+++ b/lib/presentation/widgets/profile_header.dart
@@ -38,18 +38,26 @@ class ProfileHeader extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(
-                  nickname,
-                  style: AppTypography.subtitle16SemiBold.copyWith(
-                    color: AppColors.white,
-                  ),
-                ),
-                const SizedBox(height: 4),
-                Text(
-                  '맛상추와 함께한지 $daysTogether일째\n그동안 총 $travelCount번의 여행을 떠났어요 :)',
-                  style: AppTypography.caption12Regular.copyWith(
-                    color: AppColors.white,
-                    height: 1.4,
+                Text.rich(
+                  TextSpan(
+                    style: AppTypography.caption12Regular.copyWith(
+                      color: AppColors.white,
+                      height: 1.4,
+                    ),
+                    children: [
+                      const TextSpan(text: '맛상추와 함께한지 '),
+                      TextSpan(
+                        text: '$daysTogether일',
+                        style: AppTypography.button14.copyWith(color: AppColors.white),
+                      ),
+                      const TextSpan(text: ' 째'),
+                      const TextSpan(text: '\n그동안 총 '),
+                      TextSpan(
+                        text: '$travelCount번',
+                        style: AppTypography.button14.copyWith(color: AppColors.white),
+                      ),
+                      const TextSpan(text: '의 여행을 떠났어요 :)'),
+                    ],
                   ),
                 ),
               ],


### PR DESCRIPTION
1. 공지사항(MyPageNoticeScreen) 관련 수정 사항 요약
1) 상단 제목 영역 사용자 정의
기존 AppBar를 제거하고 직접 마진 25px, 상단 66px로 정렬된 타이틀로 변경

2) 리스트 항목 좌우 여백 조정
공지사항 항목의 좌측 마진이 제목과 일치하도록 padding: EdgeInsets.symmetric(horizontal: 25)로 통일

3) 폰트 스타일 유지
공지사항 타이틀: body16Regular, 날짜: caption12Regular로 지정

2. 고객센터(SupportCenterScreen) 관련 수정 사항 요약
1) AppBar 제거 후 사용자 정의 헤더 적용
- 타이틀 "문의하기"를 좌측 정렬 및 마진 EdgeInsets.fromLTRB(25, 66, 16, 8)으로 지정
- 뒤로가기 아이콘 제거

2) 공지 섹션 디자인 개선
- 배경색: AppColors.neutral10
- "공지" 텍스트 강조 (caption12SemiBold, indigo80)
- 내용은 ellipsis 처리되도록 구성
- 문의 리스트 + 상담 항목 분리 구현
- 각 항목 SettingsListItem 컴포넌트로 통일하여 유지 보수성 확보
- 일반 문의 항목은 이모지 사용 (leadingIcon: Text(emoji))
- Image.asset()으로 아이콘 이미지 사용 가능하도록 분리 적용
- 고객센터 안내 하단에 문구 추가
- 하단 BottomNavBar 추가 및 selectedIndex 2로 마이페이지와 연결